### PR TITLE
fix(release): use default versioning strategy for release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,6 +10,6 @@
       "changelog-path": "CHANGELOG.md"
     }
   },
-  "versioning": "semver",
+  "versioning": "default",
   "initial-version": "0.3.0"
 }


### PR DESCRIPTION
## Summary

- Change `"versioning": "semver"` to `"versioning": "default"` in `release-please-config.json`

## Problem

Release Please v17 removed the `semver` versioning strategy type. The workflow was failing immediately after the PR #2 merge with:

```
Error: Unknown versioning strategy type: semver
```

The correct value is `default` (which implements semver behaviour in v17+).

## Test Plan

- [ ] `release-please.yml` workflow completes without errors on next push to main

Closes #3