### PR TITLE
ci(release-please): use sw-release-bot app token for PR creation

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,8 +13,16 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate release bot token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf
+        with:
+          app-id: ${{ secrets.RELEASER_APP_ID }}
+          private-key: ${{ secrets.RELEASER_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38  # v4
         id: rp
         with:
+          token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary

- Add `actions/create-github-app-token` step using `RELEASER_APP_ID` / `RELEASER_APP_PRIVATE_KEY`
- Pass the generated token to `googleapis/release-please-action`

## Problem

Release Please fails with:
```
GitHub Actions is not permitted to create or approve pull requests
```

The `structured-world` org blocks `GITHUB_TOKEN` from creating PRs. Other workflows in the org (e.g. `publish.yml` in `structured-world/repo`) already use the sw-release-bot GitHub App token for this purpose — same pattern applied here.

Closes #4