### PR TITLE
fix(release): pin build version via SETUPTOOLS_SCM_PRETEND_VERSION

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,10 @@ jobs:
 
       - name: Build wheel + sdist
         working-directory: ${{ matrix.package.path }}
-        run: uv run python -m build
+        run: |
+          # Force hatch-vcs / setuptools_scm to use the tag version, not dirty-tree dev version
+          export SETUPTOOLS_SCM_PRETEND_VERSION="${GITHUB_REF_NAME#v}"
+          uv run python -m build
 
       - name: Upload dist artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4


### PR DESCRIPTION
## Summary

- hatch-vcs detects dirty working tree (submodule state at checkout) and appends local version identifier
- All 3 packages were built as `0.4.1.dev0+gca4e2abe0.d20260409` instead of `0.4.0`
- PyPI rejects packages with local version identifiers (`+...` suffix)

## Fix

Set `SETUPTOOLS_SCM_PRETEND_VERSION` env var in the build step, stripping `v` prefix from tag name (`v0.4.0` → `0.4.0`). This forces hatch-vcs to use the exact tag version regardless of working tree state.

## After merge

Will need to re-tag `v0.4.0` on the new merge commit to trigger Release workflow with the fixed workflow file.