### PR TITLE
fix(coordinode): fix empty wheel — use sources mapping instead of packages

### DIFF
--- a/coordinode/pyproject.toml
+++ b/coordinode/pyproject.toml
@@ -51,7 +51,7 @@ raw-options = {root = ".."}
 version-file = "_version.py"
 
 [tool.hatch.build.targets.wheel]
-packages = ["coordinode"]
+sources = {"." = "coordinode"}
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
## Summary

- Fix `coordinode` wheel containing 0 Python files (package was unimportable after PyPI install)

## Root Cause

`packages = ["coordinode"]` in `coordinode/pyproject.toml` tells hatchling to look for a `coordinode/coordinode/` subdirectory. Since `pyproject.toml` lives *inside* the `coordinode/` project directory (alongside `__init__.py`), no such subdirectory exists — resulting in an empty wheel.

## Fix

```toml
# Before (broken):
[tool.hatch.build.targets.wheel]
packages = ["coordinode"]

# After (correct):
[tool.hatch.build.targets.wheel]
sources = {"." = "coordinode"}
```

`sources = {"." = "coordinode"}` maps the current directory (`.`) as the `coordinode` package root, so all `.py` files are included under the `coordinode/` namespace in the wheel.

## Test Plan

- [ ] Build wheel locally: `uv run python -m build` in `coordinode/` — verify wheel contains `coordinode/__init__.py` and other modules
- [ ] After merge and release, verify `pip install coordinode && python -c "from coordinode import CoordinodeClient"` succeeds

Closes #8