### PR TITLE
fix(ci): install workspace packages as editable + fix lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --all-packages
 
       - name: Generate proto stubs
         run: uv run make proto
@@ -80,7 +80,7 @@ jobs:
 
       - name: Install + generate proto
         run: |
-          uv sync
+          uv sync --all-packages
           uv run make proto
 
       - name: Integration tests

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ lint:
 	ruff format --check coordinode/ langchain-coordinode/ llama-index-coordinode/ tests/
 
 clean:
-	rm -rf $(PROTO_OUT)/coordinode $(PROTO_OUT)/google
+	rm -rf $(PROTO_OUT)
 	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 	find . -type d -name "*.egg-info" -exec rm -rf {} + 2>/dev/null || true
 	find . -type d -name dist -exec rm -rf {} + 2>/dev/null || true

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ lint:
 	ruff format --check coordinode/ langchain-coordinode/ llama-index-coordinode/ tests/
 
 clean:
-	rm -rf $(PROTO_OUT)/coordinode
+	rm -rf $(PROTO_OUT)/coordinode $(PROTO_OUT)/google
 	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 	find . -type d -name "*.egg-info" -exec rm -rf {} + 2>/dev/null || true
 	find . -type d -name dist -exec rm -rf {} + 2>/dev/null || true

--- a/coordinode/_proto/__init__.py
+++ b/coordinode/_proto/__init__.py
@@ -1,2 +1,0 @@
-# Generated gRPC stubs. Run `make proto` to regenerate.
-# This directory is .gitignore'd — stubs are not committed.

--- a/ruff.toml
+++ b/ruff.toml
@@ -13,3 +13,6 @@ select = ["E", "F", "I", "W", "UP"]
 ignore = [
     "E501",  # line length handled by formatter
 ]
+
+[lint.isort]
+known-first-party = ["coordinode", "langchain_coordinode", "llama_index_coordinode"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -3,7 +3,9 @@ target-version = "py311"
 
 exclude = [
     # Generated proto stubs — do not lint
-    "coordinode/_proto/",
+    "coordinode/coordinode/_proto/",
+    # Generated version files — do not lint
+    "_version.py",
 ]
 
 [lint]

--- a/ruff.toml
+++ b/ruff.toml
@@ -5,7 +5,7 @@ exclude = [
     # Generated proto stubs — do not lint
     "coordinode/coordinode/_proto/",
     # Generated version files — do not lint
-    "_version.py",
+    "**/_version.py",
 ]
 
 [lint]

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -6,6 +6,7 @@ TestToPropertyValue:   requires generated proto stubs (make proto).
 """
 
 import pytest
+
 from coordinode._types import from_property_value, to_property_value
 
 # Detect whether proto stubs have been generated.

--- a/tests/unit/test_types.py
+++ b/tests/unit/test_types.py
@@ -6,7 +6,6 @@ TestToPropertyValue:   requires generated proto stubs (make proto).
 """
 
 import pytest
-
 from coordinode._types import from_property_value, to_property_value
 
 # Detect whether proto stubs have been generated.


### PR DESCRIPTION
## Summary

- Fix `uv sync` in CI test jobs: add `--all-packages` so workspace members are installed as editable packages
- Fix `ruff.toml`: update proto stubs exclude path after package restructure in #10
- Fix `tests/unit/test_types.py`: I001 import sorting (blank line between same-group imports)
- Fix `Makefile` clean target: also removes `coordinode/_proto/google`
- Remove `coordinode/_proto/__init__.py` that was mistakenly committed (generated file)

## Root Cause

After #10 moved Python source files into `coordinode/coordinode/` subdirectory, `uv sync` without `--all-packages` no longer installs the `coordinode` workspace package as an editable. Previously, tests worked accidentally because `coordinode/__init__.py` existed at the workspace member root and Python's CWD resolution treated it as the `coordinode` package. With the new structure there's no `__init__.py` at the root, so Python sees a namespace package and `CoordinodeClient` is not found.

`uv sync --all-packages` creates a `_coordinode.pth` file pointing to the workspace member directory, which allows Python to correctly resolve `coordinode` → `coordinode/coordinode/__init__.py`.

## Verification

Locally: lint passes, 18/18 unit tests pass.

Closes #11