### PR TITLE
build(deps): bump minimum coordinode requirement to >=0.4.0

### DIFF
--- a/langchain-coordinode/pyproject.toml
+++ b/langchain-coordinode/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "coordinode>=0.3.0a1",
+    "coordinode>=0.4.0",
     "langchain-community>=0.2.0",
 ]
 

--- a/llama-index-coordinode/pyproject.toml
+++ b/llama-index-coordinode/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "coordinode>=0.3.0a1",
+    "coordinode>=0.4.0",
     "llama-index-core>=0.10.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -359,7 +359,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "coordinode-workspace"
-version = "0.4.3"
+version = "0.4.4"
 source = { virtual = "." }
 dependencies = [
     { name = "googleapis-common-protos" },


### PR DESCRIPTION
## Summary
- Update \`coordinode>=0.3.0a1\` → \`>=0.4.0\` in both adapters
- SDK is now stable at the v0.4.x series (v0.4.4 released 2026-04-09 on PyPI)

## Packages

> **Note:** There are two distinct packages with similar names:
> - **`coordinode`** — Python client SDK (this repo, [PyPI](https://pypi.org/project/coordinode/)): updated to v0.4.0–v0.4.4 today. This is the dependency being bumped.
> - **CoordiNode** — The Rust database server ([structured-world/coordinode](https://github.com/structured-world/coordinode)): latest release is v0.3.0. Integration tests run against this server.

The `coordinode>=0.4.0` constraint refers to the **Python SDK package** on PyPI, not the CoordiNode database server version.

## Test Plan
- [x] 20/20 integration tests pass using `coordinode` Python SDK v0.4.4 against CoordiNode DB v0.3.0

Closes #17