### PR TITLE
feat: similarity_search() for LangChain + upsert_relations() idempotency test

### DIFF
--- a/langchain-coordinode/langchain_coordinode/graph.py
+++ b/langchain-coordinode/langchain_coordinode/graph.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+from collections.abc import Sequence
 from typing import Any
 
 from langchain_community.graphs.graph_store import GraphStore
@@ -196,8 +197,8 @@ class CoordinodeGraph(GraphStore):
 
     def similarity_search(
         self,
-        query_vector: list[float],
-        k: int = 10,
+        query_vector: Sequence[float],
+        k: int = 5,
         label: str = "Chunk",
         property: str = "embedding",
     ) -> list[dict[str, Any]]:

--- a/langchain-coordinode/langchain_coordinode/graph.py
+++ b/langchain-coordinode/langchain_coordinode/graph.py
@@ -194,6 +194,39 @@ class CoordinodeGraph(GraphStore):
         # cypher() returns List[Dict[str, Any]] directly — column name → value.
         return self._client.cypher(query, params=params or {})
 
+    def similarity_search(
+        self,
+        query_vector: list[float],
+        k: int = 10,
+        label: str = "Chunk",
+        property: str = "embedding",
+    ) -> list[dict[str, Any]]:
+        """Find nodes whose ``property`` vector is closest to ``query_vector``.
+
+        Wraps ``CoordinodeClient.vector_search()``.  The returned list contains
+        one dict per result with the keys ``node`` (node properties), ``id``
+        (internal integer node ID), and ``distance`` (cosine distance, lower =
+        more similar).
+
+        Args:
+            query_vector: Embedding vector to search for.
+            k: Maximum number of results to return.
+            label: Node label to search (default ``"Chunk"``).
+            property: Embedding property name (default ``"embedding"``).
+
+        Returns:
+            List of result dicts sorted by ascending distance.
+        """
+        if not query_vector:
+            return []
+        results = self._client.vector_search(
+            label=label,
+            property=property,
+            vector=query_vector,
+            top_k=k,
+        )
+        return [{"id": r.node.id, "node": r.node.properties, "distance": r.distance} for r in results]
+
     # ── Lifecycle ─────────────────────────────────────────────────────────
 
     def close(self) -> None:

--- a/langchain-coordinode/langchain_coordinode/graph.py
+++ b/langchain-coordinode/langchain_coordinode/graph.py
@@ -219,11 +219,14 @@ class CoordinodeGraph(GraphStore):
         """
         if not query_vector:
             return []
-        results = self._client.vector_search(
-            label=label,
-            property=property,
-            vector=query_vector,
-            top_k=k,
+        results = sorted(
+            self._client.vector_search(
+                label=label,
+                property=property,
+                vector=query_vector,
+                top_k=k,
+            ),
+            key=lambda r: r.distance,
         )
         return [{"id": r.node.id, "node": r.node.properties, "distance": r.distance} for r in results]
 

--- a/langchain-coordinode/langchain_coordinode/graph.py
+++ b/langchain-coordinode/langchain_coordinode/graph.py
@@ -217,7 +217,10 @@ class CoordinodeGraph(GraphStore):
         Returns:
             List of result dicts sorted by ascending distance.
         """
-        if not query_vector:
+        # Use len() instead of truthiness check: numpy.ndarray (and other Sequence
+        # types) raise ValueError("The truth value of an array is ambiguous") when
+        # used in a boolean context. len() == 0 works for all sequence types.
+        if len(query_vector) == 0:
             return []
         results = sorted(
             self._client.vector_search(

--- a/tests/integration/adapters/test_langchain.py
+++ b/tests/integration/adapters/test_langchain.py
@@ -133,6 +133,44 @@ def test_add_graph_documents_idempotent(graph, unique_tag):
     assert result[0]["cnt"] == 1
 
 
+# ── similarity_search ─────────────────────────────────────────────────────────
+
+
+def test_similarity_search_returns_results(graph, unique_tag):
+    """similarity_search() returns node dicts with id, node, and distance keys.
+
+    Seeds a :LCSim node with a known embedding, then searches for the closest
+    vector. The seeded node must appear in the top-k results.
+    """
+    # Derive a unique embedding from the test tag (same technique as llama-index
+    # test) to avoid collisions with other :LCSim nodes in the shared DB.
+    seed = list(bytes.fromhex(unique_tag))
+    vec = [float(seed[i % len(seed)]) / 255.0 for i in range(16)]
+
+    try:
+        seed_rows = graph.query(
+            "CREATE (n:LCSim {id: $id, embedding: $vec}) RETURN n AS nid",
+            params={"id": f"lcsim-{unique_tag}", "vec": vec},
+        )
+        seeded_internal_id = seed_rows[0]["nid"]
+
+        results = graph.similarity_search(vec, k=5, label="LCSim", property="embedding")
+
+        assert isinstance(results, list)
+        assert len(results) >= 1
+        assert all("id" in r and "node" in r and "distance" in r for r in results)
+        assert any(r["id"] == seeded_internal_id for r in results)
+        assert results[0]["distance"] >= 0.0
+    finally:
+        graph.query("MATCH (n:LCSim {id: $id}) DELETE n", params={"id": f"lcsim-{unique_tag}"})
+
+
+def test_similarity_search_empty_vector_returns_empty(graph):
+    """similarity_search() with an empty vector list returns an empty list without error."""
+    results = graph.similarity_search([], k=5)
+    assert isinstance(results, list)
+
+
 def test_schema_refreshes_after_add(graph, unique_tag):
     """structured_schema is invalidated and re-fetched after add_graph_documents."""
     graph._schema = None  # force refresh

--- a/tests/integration/adapters/test_langchain.py
+++ b/tests/integration/adapters/test_langchain.py
@@ -152,6 +152,10 @@ def test_similarity_search_returns_results(graph, unique_tag):
             "CREATE (n:LCSim {id: $id, embedding: $vec}) RETURN n AS nid",
             params={"id": f"lcsim-{unique_tag}", "vec": vec},
         )
+        # graph.query() wraps CoordinodeClient.cypher() which returns raw dict values.
+        # CoordiNode: CREATE ... RETURN n yields the internal integer node ID directly
+        # (NOT a node object). similarity_search() also returns {"id": r.node.id, ...}
+        # where r.node.id is the same integer. Direct equality comparison is correct.
         seeded_internal_id = seed_rows[0]["nid"]
 
         results = graph.similarity_search(vec, k=5, label="LCSim", property="embedding")

--- a/tests/integration/adapters/test_langchain.py
+++ b/tests/integration/adapters/test_langchain.py
@@ -164,7 +164,7 @@ def test_similarity_search_returns_results(graph, unique_tag):
         assert len(results) >= 1
         assert all("id" in r and "node" in r and "distance" in r for r in results)
         assert any(r["id"] == seeded_internal_id for r in results)
-        assert results[0]["distance"] >= 0.0
+        assert all(results[i]["distance"] <= results[i + 1]["distance"] for i in range(len(results) - 1))
     finally:
         graph.query("MATCH (n:LCSim {id: $id}) DELETE n", params={"id": f"lcsim-{unique_tag}"})
 

--- a/tests/integration/adapters/test_langchain.py
+++ b/tests/integration/adapters/test_langchain.py
@@ -168,7 +168,7 @@ def test_similarity_search_returns_results(graph, unique_tag):
 def test_similarity_search_empty_vector_returns_empty(graph):
     """similarity_search() with an empty vector list returns an empty list without error."""
     results = graph.similarity_search([], k=5)
-    assert isinstance(results, list)
+    assert results == []
 
 
 def test_schema_refreshes_after_add(graph, unique_tag):

--- a/tests/integration/adapters/test_llama_index.py
+++ b/tests/integration/adapters/test_llama_index.py
@@ -82,9 +82,9 @@ def test_upsert_relations_idempotent(store, tag):
     store.upsert_relations([rel])
     store.upsert_relations([rel])  # second call must not duplicate
 
-    rows = store._client.cypher(
+    rows = store.structured_query(
         "MATCH (a {id: $src})-[r:LI_IDEMP_REL]->(b {id: $dst}) RETURN count(r) AS cnt",
-        params={"src": src.id, "dst": dst.id},
+        param_map={"src": src.id, "dst": dst.id},
     )
     assert rows[0]["cnt"] == 1, f"expected exactly 1 edge after double upsert, got: {rows}"
 

--- a/tests/integration/adapters/test_llama_index.py
+++ b/tests/integration/adapters/test_llama_index.py
@@ -72,6 +72,23 @@ def test_upsert_nodes_idempotent(store, tag):
     assert len(found) == 1
 
 
+def test_upsert_relations_idempotent(store, tag):
+    """Upserting the same relation twice must produce exactly one edge (MERGE idempotent)."""
+    src = EntityNode(label="LIIdempRel", name=f"IdempSrc-{tag}")
+    dst = EntityNode(label="LIIdempRel", name=f"IdempDst-{tag}")
+    store.upsert_nodes([src, dst])
+
+    rel = Relation(label="LI_IDEMP_REL", source_id=src.id, target_id=dst.id)
+    store.upsert_relations([rel])
+    store.upsert_relations([rel])  # second call must not duplicate
+
+    rows = store._client.cypher(
+        "MATCH (a {id: $src})-[r:LI_IDEMP_REL]->(b {id: $dst}) RETURN count(r) AS cnt",
+        params={"src": src.id, "dst": dst.id},
+    )
+    assert rows[0]["cnt"] == 1, f"expected exactly 1 edge after double upsert, got: {rows}"
+
+
 def test_get_by_id(store, tag):
     node = EntityNode(label="LIGetById", name=f"ById-{tag}")
     node_id = node.id


### PR DESCRIPTION
## Summary

- Add `similarity_search(query_vector, k, label, property)` to `CoordinodeGraph` (LangChain adapter), wrapping `CoordinodeClient.vector_search()` with label/property defaults
- Add `test_upsert_relations_idempotent` integration test for LlamaIndex adapter, verifying exactly 1 edge after double `upsert_relations()` call (MERGE semantics)

## Technical Details

**`similarity_search()`**:
- Returns `[{"id": ..., "node": ..., "distance": ...}, ...]` sorted by ascending cosine distance
- Guards against empty `query_vector` (server returns `INVALID_ARGUMENT` for empty vectors)
- Two integration tests: seeded `:LCSim` node found in top-k results, empty vector returns `[]`

**Idempotency test**:
- Seeds src/dst nodes, calls `upsert_relations()` twice with the same `Relation`
- Verifies `count(r) == 1` via Cypher — MERGE semantics confirmed

## Test Plan

- 55/55 integration tests pass against live CoordiNode instance

Closes #20
Closes #21