### PR TITLE
ci(release): fix embedded wheel builds for Windows, macOS, and Linux aarch64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,8 +85,9 @@ jobs:
             target: aarch64
             python-version: "3.13"
 
-          # macOS Intel
-          - os: macos-13
+          # macOS Intel (macos-13 was retired December 2025; macos-15-intel is the
+          # current Intel label)
+          - os: macos-15-intel
             target: x86_64
             python-version: "3.13"
 
@@ -110,11 +111,12 @@ jobs:
 
       # Pin Python on macOS and Windows: macos-latest ships Python 3.14 which
       # PyO3 0.23.x does not yet support. Remove when PyO3 >= 0.24 is adopted.
-      - name: Set up Python ${{ matrix.python-version }}
-        if: matrix.python-version != ''
+      # Linux builds run inside a manylinux container that manages Python itself.
+      - name: Set up Python ${{ matrix.python-version || '3.13' }}
+        if: runner.os != 'Linux'
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version || '3.13' }}
 
       # QEMU is required for maturin-action to cross-compile Linux aarch64 wheels
       # on the x86_64 ubuntu-latest runner using the manylinux container.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,21 +73,27 @@ jobs:
             manylinux: manylinux_2_28
 
           # Linux aarch64 — AWS Graviton, Raspberry Pi, etc.
+          # Requires QEMU (set up below) for cross-compilation on the x86_64 runner.
           - os: ubuntu-latest
             target: aarch64
             manylinux: manylinux_2_28
 
           # macOS Apple Silicon (M1/M2/M3)
+          # Pin to Python 3.13: macos-latest ships Python 3.14 which PyO3 0.23.x
+          # does not yet support (max supported is 3.13).
           - os: macos-latest
             target: aarch64
+            python-version: "3.13"
 
           # macOS Intel
           - os: macos-13
             target: x86_64
+            python-version: "3.13"
 
           # Windows x86_64
           - os: windows-latest
             target: x86_64
+            python-version: "3.13"
 
     runs-on: ${{ matrix.os }}
     steps:
@@ -101,6 +107,20 @@ jobs:
       # ensures the tag annotation is present for version detection.
       - name: Verify coordinode-rs submodule tag
         run: git -C coordinode-rs describe --tags --exact-match HEAD || true
+
+      # Pin Python on macOS and Windows: macos-latest ships Python 3.14 which
+      # PyO3 0.23.x does not yet support. Remove when PyO3 >= 0.24 is adopted.
+      - name: Set up Python ${{ matrix.python-version }}
+        if: matrix.python-version != ''
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # QEMU is required for maturin-action to cross-compile Linux aarch64 wheels
+      # on the x86_64 ubuntu-latest runner using the manylinux container.
+      - name: Set up QEMU
+        if: runner.os == 'Linux' && matrix.target == 'aarch64'
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff9f9a89f41e8f8e6f3  # v3
 
       - name: Install protoc (macOS / Windows)
         if: runner.os != 'Linux'


### PR DESCRIPTION
## Summary

Three independent failures in the `build-embedded` matrix discovered in the cancelled v0.8.0 release run.

## Root Causes & Fixes

### 1. Windows x86_64 — UNC path rejected by protoc

`std::path::Path::canonicalize()` on Windows returns `\\?\D:\...` (extended-length UNC prefix) that protoc rejects with _"Invalid file name pattern"_.

Fix: `canonicalize_for_protoc()` helper strips the `\\?\` prefix in all four `build.rs` files inside `coordinode-rs`. Applied in the submodule on branch `fix/windows-protoc-unc-path` → [structured-world/coordinode](https://github.com/structured-world/coordinode); this PR bumps the submodule pointer to that commit.

### 2. macOS aarch64 / x86_64 — Python 3.14 not yet supported by PyO3

`macos-latest` now ships Python 3.14. PyO3 0.23.5 supports up to Python 3.13 and fails with:
```
error: the configured Python interpreter version (3.14) is newer than PyO3's maximum supported version (3.13)
```

Fix: Add `actions/setup-python` step pinned to `3.13` for all non-Linux matrix entries. Remove pin when PyO3 ≥ 0.24 is adopted.

### 3. Ubuntu aarch64 — Docker not found for cross-compilation

`maturin-action` uses a manylinux Docker container to cross-compile aarch64 wheels on the x86_64 runner. Docker wasn't available in the runner context (`/usr/bin/docker: exit code 127`).

Fix: Add `docker/setup-qemu-action` before the maturin step for Linux aarch64 targets.

## Test Plan

- [ ] Merge submodule PR in structured-world/coordinode first
- [ ] Trigger a pre-release tag to verify all 5 matrix jobs pass

Closes #39