### PR TITLE
fix(release): handle missing dnf in aarch64 manylinux container

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,9 @@ jobs:
           manylinux: ${{ matrix.manylinux || 'auto' }}
           target: ${{ matrix.target }}
           before-script-linux: |
-            dnf install -y protobuf-compiler
+            command -v dnf  && dnf  install -y   protobuf-compiler ||
+            command -v yum  && yum  install -y   protobuf-compiler ||
+            command -v apt-get && apt-get install -y -q protobuf-compiler
 
       - name: Upload wheels
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4


### PR DESCRIPTION
## Summary

- `Build embedded / aarch64 (ubuntu-latest)` fails in Release v1.0.1 with `dnf: command not found` → docker exits 127
- aarch64 manylinux_2_28 container doesn't expose `dnf` in PATH; before-script falls through with exit code 127
- Fix: fall through `dnf` → `yum` → `apt-get` so protoc installs regardless of package manager

Closes #52