### PR TITLE
fix(release): use if/else for protoc install, add apt-get update for aarch64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,9 +142,11 @@ jobs:
           manylinux: ${{ matrix.manylinux || 'auto' }}
           target: ${{ matrix.target }}
           before-script-linux: |
-            command -v dnf  && dnf  install -y   protobuf-compiler ||
-            command -v yum  && yum  install -y   protobuf-compiler ||
-            command -v apt-get && apt-get install -y -q protobuf-compiler
+            if command -v dnf >/dev/null 2>&1; then
+              dnf install -y protobuf-compiler
+            else
+              apt-get update -q && apt-get install -y -q protobuf-compiler
+            fi
 
       - name: Upload wheels
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4


### PR DESCRIPTION
## Summary

Root cause of `Build embedded / aarch64 (ubuntu-latest)` failures across v1.0.0–v1.0.2:

**v1.0.0–v1.0.1:** QEMU action SHA broken (fixed in #50)
**v1.0.1:** `dnf` not found → `apt-get` 404 (stale package list, fixed in #53 but incomplete)
**v1.0.2:** `||` chain causes both `dnf` AND `yum` to run (AlmaLinux 8 has `yum` as alias for `dnf`) — both succeed, then `apt-get` tried and fails with "command not found" inside the manylinux x86_64 container

Fix: replace `||` chain with `if/else`:
- `dnf` present → manylinux x86_64 (AlmaLinux 8) → `dnf install`
- else → rust-cross aarch64 (Debian) → `apt-get update && apt-get install`

Closes #55