### PR TITLE
fix(ci): set PYO3_CROSS_PYTHON_VERSION for aarch64 Linux cross-compilation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,10 +73,13 @@ jobs:
             manylinux: manylinux_2_28
 
           # Linux aarch64 — AWS Graviton, Raspberry Pi, etc.
-          # Requires QEMU (set up below) for cross-compilation on the x86_64 runner.
+          # Cross-compiled on the x86_64 runner using rust-cross container.
+          # rust-cross/manylinux_2_28-cross has no Python, so PYO3_CROSS_PYTHON_VERSION
+          # tells PyO3 which version to target without needing a Python binary.
           - os: ubuntu-latest
             target: aarch64
             manylinux: manylinux_2_28
+            pyo3_cross_python_version: "3.11"
 
           # macOS Apple Silicon (M1/M2/M3)
           # Pin to Python 3.13: macos-latest ships Python 3.14 which PyO3 0.23.x
@@ -132,6 +135,8 @@ jobs:
 
       - name: Build wheels
         uses: PyO3/maturin-action@32307a466a178317e8c2ae343b38e73896a047be  # v1.47.0
+        env:
+          PYO3_CROSS_PYTHON_VERSION: ${{ matrix.pyo3_cross_python_version }}
         with:
           command: build
           args: >-


### PR DESCRIPTION
## Problem

`Build embedded / aarch64 (ubuntu-latest)` fails with:
```
💥 maturin failed
  Caused by: Couldn't find any python interpreters. Please specify at least one with -i
```

`maturin-action` v1.47.0 with `manylinux_2_28` + `target: aarch64` on an x86_64 runner uses `ghcr.io/rust-cross/manylinux_2_28-cross:aarch64` — a Debian-based cross-compilation container with **no Python interpreters**.

## Fix

Set `PYO3_CROSS_PYTHON_VERSION=3.11` for the aarch64 Linux matrix entry. This tells PyO3 to generate bindings for Python 3.11 without needing a Python binary in the container — the standard approach for cross-compilation without QEMU emulation.

The env var is only set for the aarch64 Linux matrix entry; other entries have it empty/unset. PyO3 ignores it on native builds where Python is available.