### PR TITLE
fix(ci): remove PYO3_CROSS_PYTHON_VERSION, use pypa manylinux image for aarch64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,8 @@ jobs:
           # Python 3.11–3.13 preinstalled. Slower than cross-compilation but correct.
           - os: ubuntu-latest
             target: aarch64
-            manylinux: quay.io/pypa/manylinux_2_28_aarch64
+            manylinux: manylinux_2_28
+            container: quay.io/pypa/manylinux_2_28_aarch64
 
           # macOS Apple Silicon (M1/M2/M3)
           # Pin to Python 3.13: macos-latest ships Python 3.14 which PyO3 0.23.x
@@ -142,6 +143,7 @@ jobs:
             --manifest-path coordinode-embedded/Cargo.toml
             --out dist
           manylinux: ${{ matrix.manylinux || 'auto' }}
+          container: ${{ matrix.container || '' }}
           target: ${{ matrix.target }}
           before-script-linux: |
             if command -v dnf >/dev/null 2>&1; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,13 +73,12 @@ jobs:
             manylinux: manylinux_2_28
 
           # Linux aarch64 — AWS Graviton, Raspberry Pi, etc.
-          # Cross-compiled on the x86_64 runner using rust-cross container.
-          # rust-cross/manylinux_2_28-cross has no Python, so PYO3_CROSS_PYTHON_VERSION
-          # tells PyO3 which version to target without needing a Python binary.
+          # Uses the official pypa manylinux_2_28 aarch64 image via QEMU emulation.
+          # The rust-cross container has no Python, so we use the pypa image which has
+          # Python 3.11–3.13 preinstalled. Slower than cross-compilation but correct.
           - os: ubuntu-latest
             target: aarch64
-            manylinux: manylinux_2_28
-            pyo3_cross_python_version: "3.11"
+            manylinux: quay.io/pypa/manylinux_2_28_aarch64
 
           # macOS Apple Silicon (M1/M2/M3)
           # Pin to Python 3.13: macos-latest ships Python 3.14 which PyO3 0.23.x
@@ -135,8 +134,6 @@ jobs:
 
       - name: Build wheels
         uses: PyO3/maturin-action@32307a466a178317e8c2ae343b38e73896a047be  # v1.47.0
-        env:
-          PYO3_CROSS_PYTHON_VERSION: ${{ matrix.pyo3_cross_python_version }}
         with:
           command: build
           args: >-


### PR DESCRIPTION
## Problem

PR #58 introduced \`PYO3_CROSS_PYTHON_VERSION: \${{ matrix.pyo3_cross_python_version }}\` on the maturin build step. For all matrix entries except aarch64 Linux, this variable is unset, so GitHub Actions passes it as an empty string \`""\`.

PyO3's build script fails to parse the empty string as a version:
\`\`\`
error: failed to parse PYO3_CROSS_PYTHON_VERSION
caused by:
  - 0: expected major.minor version
\`\`\`

This breaks **all** `build-embedded` jobs (x86_64 Linux, macOS, Windows, aarch64).

## Fix

1. Remove the `PYO3_CROSS_PYTHON_VERSION` env var entirely from the build step.
2. For aarch64 Linux: use `quay.io/pypa/manylinux_2_28_aarch64` (official pypa image with Python 3.11–3.13) via QEMU emulation instead of the rust-cross container that has no Python. QEMU is already set up in the workflow.