### PR TITLE
fix(embedded): enable abi3-py311 for cross-version wheel compatibility

### DIFF
--- a/coordinode-embedded/Cargo.toml
+++ b/coordinode-embedded/Cargo.toml
@@ -13,7 +13,7 @@ name = "_coordinode_embedded"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.23", features = ["extension-module"] }
+pyo3 = { version = "0.23", features = ["extension-module", "abi3-py311"] }
 coordinode-embed = { path = "../coordinode-rs/crates/coordinode-embed" }
 coordinode-core = { path = "../coordinode-rs/crates/coordinode-core" }
 rmpv = "1"

--- a/uv.lock
+++ b/uv.lock
@@ -359,7 +359,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "coordinode-workspace"
-version = "0.7.0"
+version = "1.0.5"
 source = { virtual = "." }
 dependencies = [
     { name = "googleapis-common-protos" },


### PR DESCRIPTION
## Summary

- `coordinode-embedded` was publishing only `cp311` wheels for Linux (CI runner has Python 3.11)
- Google Colab runs **Python 3.12** — pip cannot find a compatible wheel → installation fails
- Fix: add `abi3-py311` feature to pyo3, producing a single `cp311-abi3` wheel per platform
- The `cp311-abi3` wheel is compatible with Python **3.11, 3.12, 3.13, 3.14+** automatically

## Change

One line in `coordinode-embedded/Cargo.toml`:
```toml
pyo3 = { version = "0.23", features = ["extension-module", "abi3-py311"] }
```

maturin detects `abi3-py311` and sets the wheel tag accordingly. No CI matrix changes needed.

## Verified locally

```
📦 Built wheel for abi3 Python ≥ 3.11 to coordinode_embedded-0.1.0-cp311-abi3-macosx_11_0_arm64.whl
```
Installed successfully on Python 3.12 (`uv run python` = 3.12.11).

Closes #65