### PR TITLE
ci: add Python 3.14 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:


### PR DESCRIPTION
## Summary

- Add Python 3.14 to the unit test matrix alongside 3.11, 3.12, 3.13
- `coordinode-embedded` now publishes `cp311-abi3` wheels (compatible with 3.11+), so CI should validate the SDK on 3.14 as well

Closes #67