### PR TITLE
feat(embedded): add native Hnsw class for ann-benchmarks integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,27 @@ jobs:
           before-script-linux: |
             dnf install -y protobuf-compiler
 
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4
+        with:
+          python-version: "3.12"
+
+      - name: Install wheel + run embedded tests
+        # The main `test` job skips coordinode_embedded with importorskip
+        # because that runner doesn't build the wheel.  This job has the
+        # wheel — install it and run the embedded tests here, with
+        # --strict-markers so a silent skip surfaces as a CI failure.
+        run: |
+          set -euo pipefail
+          WHL=$(ls /tmp/embedded-dist/coordinode_embedded-*.whl | head -1)
+          test -n "$WHL"
+          uv venv --python 3.12 /tmp/test-venv
+          uv pip install --python /tmp/test-venv/bin/python "$WHL" numpy pytest pytest-timeout
+          /tmp/test-venv/bin/python -m pytest tests/unit/test_hnsw.py -v --strict-markers -ra
+          # Fail if any test was skipped — importorskip is intentional, but
+          # in this job the wheel IS installed, so a skip means something is
+          # genuinely broken (wrong manylinux glibc, missing numpy, ...).
+          test "$(/tmp/test-venv/bin/python -m pytest tests/unit/test_hnsw.py --collect-only -q 2>&1 | grep -c 'test_')" -gt 0
+
   test-integration:
     name: Integration tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,10 @@ jobs:
       - name: Install wheel + run embedded tests
         # The main `test` job skips coordinode_embedded with importorskip
         # because that runner doesn't build the wheel.  This job has the
-        # wheel — install it and run the embedded tests here, with
-        # --strict-markers so a silent skip surfaces as a CI failure.
+        # wheel — install it and run the embedded tests here, then assert
+        # nothing was skipped (a skip with the wheel installed means a
+        # broken manylinux glibc / missing numpy / etc., not the expected
+        # "no wheel" condition).
         # maturin-action runs inside a manylinux container; only paths
         # under $GITHUB_WORKSPACE are bind-mounted back to the host, so
         # the wheel goes to ./dist/ (workspace-relative), not /tmp/.
@@ -82,11 +84,20 @@ jobs:
           test -n "$WHL"
           uv venv --python 3.12 /tmp/test-venv
           uv pip install --python /tmp/test-venv/bin/python "$WHL" numpy pytest pytest-timeout
-          /tmp/test-venv/bin/python -m pytest tests/unit/test_hnsw.py -v --strict-markers -ra
-          # Fail if any test was skipped — importorskip is intentional, but
-          # in this job the wheel IS installed, so a skip means something is
-          # genuinely broken (wrong manylinux glibc, missing numpy, ...).
-          test "$(/tmp/test-venv/bin/python -m pytest tests/unit/test_hnsw.py --collect-only -q 2>&1 | grep -c 'test_')" -gt 0
+          OUTPUT=$(/tmp/test-venv/bin/python -m pytest tests/unit/test_hnsw.py -v --strict-markers -ra 2>&1)
+          echo "$OUTPUT"
+          # `-ra` prints a "SKIPPED [N]" short summary header when anything was
+          # skipped; importorskip-based skip also surfaces this way.  Use the
+          # full output instead of the exit code because pytest treats skips
+          # as success.
+          if echo "$OUTPUT" | grep -qE '^SKIPPED|=+ .* skipped'; then
+            echo "::error::Tests were skipped in build-embedded; the wheel is installed so this is a real failure (broken glibc / missing numpy / etc.)"
+            exit 1
+          fi
+          if ! echo "$OUTPUT" | grep -qE '=+ [0-9]+ passed'; then
+            echo "::error::No tests passed — the module was likely not collected"
+            exit 1
+          fi
 
   test-integration:
     name: Integration tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           command: build
           args: >-
             --manifest-path coordinode-embedded/Cargo.toml
-            --out /tmp/embedded-dist
+            --out dist
           manylinux: manylinux_2_28
           before-script-linux: |
             dnf install -y protobuf-compiler
@@ -73,9 +73,12 @@ jobs:
         # because that runner doesn't build the wheel.  This job has the
         # wheel — install it and run the embedded tests here, with
         # --strict-markers so a silent skip surfaces as a CI failure.
+        # maturin-action runs inside a manylinux container; only paths
+        # under $GITHUB_WORKSPACE are bind-mounted back to the host, so
+        # the wheel goes to ./dist/ (workspace-relative), not /tmp/.
         run: |
           set -euo pipefail
-          WHL=$(ls /tmp/embedded-dist/coordinode_embedded-*.whl | head -1)
+          WHL=$(ls dist/coordinode_embedded-*.whl | head -1)
           test -n "$WHL"
           uv venv --python 3.12 /tmp/test-venv
           uv pip install --python /tmp/test-venv/bin/python "$WHL" numpy pytest pytest-timeout

--- a/coordinode-embedded/Cargo.lock
+++ b/coordinode-embedded/Cargo.lock
@@ -231,6 +231,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "backoff-series"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b143524c9d0b6c3e8e80542a0a17e1e472ccfd5a3d3696bd6ad2b18248d3350"
+
+[[package]]
+name = "base2histogram"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d74d05707c315a6c0601b1089186476cf11ee5fe8d6e035ea43c44ae1a0215cd"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,8 +456,32 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf",
+ "serde",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
+dependencies = [
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
 ]
 
 [[package]]
@@ -533,7 +569,7 @@ dependencies = [
 
 [[package]]
 name = "coordinode-core"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "bytes",
  "rmp",
@@ -549,9 +585,11 @@ dependencies = [
 
 [[package]]
 name = "coordinode-embed"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "coordinode-core",
+ "coordinode-lsm-tree",
+ "coordinode-modality",
  "coordinode-query",
  "coordinode-raft",
  "coordinode-search",
@@ -571,6 +609,8 @@ version = "0.1.0"
 dependencies = [
  "coordinode-core",
  "coordinode-embed",
+ "coordinode-vector",
+ "numpy",
  "pyo3",
  "rmpv",
  "tempfile",
@@ -598,10 +638,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "coordinode-query"
-version = "0.4.1"
+name = "coordinode-modality"
+version = "0.4.3"
 dependencies = [
  "coordinode-core",
+ "coordinode-lsm-tree",
+ "coordinode-storage",
+ "coordinode-vector",
+ "rmp-serde",
+ "rmpv",
+ "serde",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "coordinode-query"
+version = "0.4.3"
+dependencies = [
+ "coordinode-core",
+ "coordinode-modality",
  "coordinode-search",
  "coordinode-storage",
  "coordinode-vector",
@@ -618,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "coordinode-raft"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "bytes",
  "coordinode-core",
@@ -640,7 +696,7 @@ dependencies = [
 
 [[package]]
 name = "coordinode-search"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "aes-gcm",
  "coordinode-storage",
@@ -657,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "coordinode-storage"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "byteorder-lite",
  "bytes",
@@ -670,6 +726,7 @@ dependencies = [
  "flume",
  "log",
  "lz4_flex",
+ "metrics",
  "rayon",
  "rmp-serde",
  "rmpv",
@@ -683,10 +740,13 @@ dependencies = [
 
 [[package]]
 name = "coordinode-vector"
-version = "0.4.1"
+version = "0.4.3"
 dependencies = [
  "coordinode-core",
  "coordinode-storage",
+ "crossbeam-epoch",
+ "loom",
+ "rayon",
  "serde",
  "thiserror",
  "tracing",
@@ -922,6 +982,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "display-more"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf8aaad655bf39f0691f6f4025a8b58f1ff46fb12cb70f6d69e4f0dd2eb717a8"
+dependencies = [
+ "chrono",
+ "chrono-tz",
+]
+
+[[package]]
 name = "downcast-rs"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -975,7 +1045,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1094,6 +1164,21 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
 ]
 
 [[package]]
@@ -1471,6 +1556,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1510,6 +1601,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lru"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,10 +1638,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
 
 [[package]]
 name = "measure_time"
@@ -1618,6 +1741,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
+name = "ndarray"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1628,10 +1766,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1640,6 +1805,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "numpy"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94caae805f998a07d33af06e6a3891e38556051b8045c615470a71590e13e78"
+dependencies = [
+ "libc",
+ "ndarray",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "pyo3",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -1668,23 +1848,28 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openraft"
-version = "0.10.0-alpha.17"
+version = "0.10.0-alpha.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b9d8db10f834d517e4c2c45ab5c645bc5cafee9d07f7b150b8029a0b1ebdca"
+checksum = "42a7b7775774f72c1ec9c4a7a74ec5274515c66c0af40b0f8119ebd36ec3fde4"
 dependencies = [
  "anyerror",
+ "backoff-series",
+ "base2histogram",
  "byte-unit",
  "chrono",
  "clap",
  "derive_more",
+ "display-more",
  "futures-util",
+ "itertools",
  "maplit",
  "openraft-macros",
  "openraft-rt",
  "openraft-rt-tokio",
  "peel-off",
- "rand 0.9.3",
+ "rand 0.10.1",
  "serde",
+ "smallvec",
  "thiserror",
  "tracing",
  "validit",
@@ -1692,9 +1877,9 @@ dependencies = [
 
 [[package]]
 name = "openraft-macros"
-version = "0.10.0-alpha.17"
+version = "0.10.0-alpha.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22b0bd215948ed47997a1d0447ea592e49220096360a833b118f329a08aa286"
+checksum = "880853cd85c2dd7883122134abcc5483005dd175d6027e9e00c1eede8fd2a956"
 dependencies = [
  "chrono",
  "proc-macro2",
@@ -1705,25 +1890,26 @@ dependencies = [
 
 [[package]]
 name = "openraft-rt"
-version = "0.10.0-alpha.17"
+version = "0.10.0-alpha.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55b651e6e2f25d022e34549e605eb8875c78ebc26862b16b06143a551e53ec00"
+checksum = "0ba87cea8e45601807f2537fd9e657e02c9ee2fdaa9be4ece013b296b03b2c97"
 dependencies = [
  "futures-channel",
  "futures-util",
  "openraft-macros",
- "rand 0.9.3",
+ "pin-project-lite",
+ "rand 0.10.1",
 ]
 
 [[package]]
 name = "openraft-rt-tokio"
-version = "0.10.0-alpha.17"
+version = "0.10.0-alpha.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478d5625fdeb13293e68549ba1d42b7a25085f3be04204412147637ad22e2827"
+checksum = "2a539ef5ef89d4da720c56300aeb702d6ddf2a9fa653b029b79d30e5f8cf68fa"
 dependencies = [
  "futures-util",
  "openraft-rt",
- "rand 0.9.3",
+ "rand 0.10.1",
  "tokio",
 ]
 
@@ -1766,6 +1952,15 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "parse-zoneinfo"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
+dependencies = [
+ "regex",
 ]
 
 [[package]]
@@ -1835,6 +2030,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1883,6 +2116,15 @@ name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "powerfmt"
@@ -2127,18 +2369,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
-dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2163,16 +2395,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2183,18 +2405,15 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
@@ -2403,7 +2622,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2423,6 +2642,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -2535,6 +2760,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2555,6 +2789,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "sketches-ddsketch"
@@ -2822,7 +3062,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2843,6 +3083,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -3101,6 +3350,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -3235,6 +3514,12 @@ checksum = "4efba0434d5a0a62d4f22070b44ce055dc18cb64d4fa98276aa523dadfaba0e7"
 dependencies = [
  "anyerror",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "varint-rs"

--- a/coordinode-embedded/Cargo.toml
+++ b/coordinode-embedded/Cargo.toml
@@ -14,8 +14,10 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.24", features = ["extension-module", "abi3-py311"] }
+numpy = "0.24"
 coordinode-embed = { path = "../coordinode-rs/crates/coordinode-embed" }
 coordinode-core = { path = "../coordinode-rs/crates/coordinode-core" }
+coordinode-vector = { path = "../coordinode-rs/crates/coordinode-vector" }
 rmpv = "1"
 tempfile = "3"
 

--- a/coordinode-embedded/pyproject.toml
+++ b/coordinode-embedded/pyproject.toml
@@ -22,9 +22,11 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dynamic = ["version"]
-# The compiled extension links against NumPy's C API at runtime (via the Rust
-# `numpy` crate).  `import coordinode_embedded` triggers `import numpy.core`
-# under the hood — without NumPy installed the extension panics on first call.
+# The compiled extension links against NumPy's C API via the Rust `numpy`
+# crate, which imports `numpy.core` lazily on the first PyArray operation
+# (`Hnsw.fit`, `Hnsw.knn_query`, ...).  Without NumPy installed the wheel
+# imports fine but the first PyArray call panics — declare NumPy as a
+# runtime dependency so `pip install coordinode-embedded` pulls it in.
 # Pin the lower bound to the oldest release that ships matching ABI headers
 # for cp311/312/313/314 wheels.
 dependencies = [

--- a/coordinode-embedded/pyproject.toml
+++ b/coordinode-embedded/pyproject.toml
@@ -22,6 +22,14 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dynamic = ["version"]
+# The compiled extension links against NumPy's C API at runtime (via the Rust
+# `numpy` crate).  `import coordinode_embedded` triggers `import numpy.core`
+# under the hood — without NumPy installed the extension panics on first call.
+# Pin the lower bound to the oldest release that ships matching ABI headers
+# for cp311/312/313/314 wheels.
+dependencies = [
+    "numpy>=1.26",
+]
 
 [project.urls]
 Homepage = "https://coordinode.dev"

--- a/coordinode-embedded/python/coordinode_embedded/__init__.py
+++ b/coordinode-embedded/python/coordinode_embedded/__init__.py
@@ -21,6 +21,6 @@ Example::
     db.close()
 """
 
-from ._coordinode_embedded import LocalClient
+from ._coordinode_embedded import Hnsw, LocalClient
 
-__all__ = ["LocalClient"]
+__all__ = ["Hnsw", "LocalClient"]

--- a/coordinode-embedded/python/coordinode_embedded/_coordinode_embedded.pyi
+++ b/coordinode-embedded/python/coordinode_embedded/_coordinode_embedded.pyi
@@ -15,9 +15,11 @@ class Hnsw:
     Args:
         dim: Embedding dimension.  Must match the vectors passed to ``fit``
              and ``knn_query``.
-        metric: Distance metric — one of ``"cosine"`` / ``"angular"``,
-                ``"euclidean"`` / ``"l2"``, ``"dot"`` / ``"inner_product"``,
-                ``"manhattan"`` / ``"l1"``.
+        metric: Distance metric. Accepted spellings (case-insensitive):
+                  - cosine similarity: ``"cosine"``, ``"angular"``
+                  - Euclidean (L2):    ``"euclidean"``, ``"l2"``
+                  - dot product:       ``"dot"``, ``"dot_product"``, ``"ip"``, ``"inner_product"``
+                  - Manhattan (L1):    ``"manhattan"``, ``"l1"``
         M: Max connections per element per layer (HNSW spec). Default 16.
         ef_construction: Candidate list size during build. Default 200.
         max_elements: Hint to pre-allocate node storage. Default 1_000_000.

--- a/coordinode-embedded/python/coordinode_embedded/_coordinode_embedded.pyi
+++ b/coordinode-embedded/python/coordinode_embedded/_coordinode_embedded.pyi
@@ -2,6 +2,69 @@
 
 from typing import Any
 
+import numpy as np
+import numpy.typing as npt
+
+class Hnsw:
+    """In-process HNSW index — fast-path bypass around Cypher.
+
+    Use this when you want library-grade vector search throughput without
+    the Cypher parser/planner cost.  Mirrors the hnswlib / FAISS-HNSW
+    surface used by the ann-benchmarks harness.
+
+    Args:
+        dim: Embedding dimension.  Must match the vectors passed to ``fit``
+             and ``knn_query``.
+        metric: Distance metric — one of ``"cosine"`` / ``"angular"``,
+                ``"euclidean"`` / ``"l2"``, ``"dot"`` / ``"inner_product"``,
+                ``"manhattan"`` / ``"l1"``.
+        M: Max connections per element per layer (HNSW spec). Default 16.
+        ef_construction: Candidate list size during build. Default 200.
+        max_elements: Hint to pre-allocate node storage. Default 1_000_000.
+
+    Example::
+
+        import numpy as np
+        from coordinode_embedded import Hnsw
+
+        rng = np.random.default_rng(42)
+        X = rng.standard_normal((10_000, 128), dtype=np.float32)
+        q = rng.standard_normal(128, dtype=np.float32)
+
+        idx = Hnsw(dim=128, metric="euclidean", M=16, ef_construction=200)
+        idx.fit(X)
+        idx.set_ef(80)
+        labels = idx.knn_query(q, k=10)   # int64 ndarray, shape (10,)
+    """
+
+    def __init__(
+        self,
+        dim: int,
+        metric: str,
+        M: int = 16,
+        ef_construction: int = 200,
+        max_elements: int = 1_000_000,
+    ) -> None: ...
+    def fit(self, vectors: npt.NDArray[np.float32]) -> tuple[int, int]:
+        """Bulk-insert vectors.  Returns the contiguous ``(start, end)`` ID range
+        assigned to this batch.  Multiple ``fit`` calls extend the index rather
+        than replacing it.
+        """
+        ...
+
+    def set_ef(self, ef: int) -> None:
+        """Update runtime ``ef_search``. Higher ef = higher recall, lower QPS."""
+        ...
+
+    def knn_query(
+        self, query: npt.NDArray[np.float32], k: int
+    ) -> npt.NDArray[np.int64]:
+        """k-NN query.  Returns nearest neighbour IDs, ordered nearest-first."""
+        ...
+
+    def __len__(self) -> int: ...
+    def __repr__(self) -> str: ...
+
 class LocalClient:
     """In-process CoordiNode database — no server, no Docker required.
 

--- a/coordinode-embedded/src/hnsw.rs
+++ b/coordinode-embedded/src/hnsw.rs
@@ -64,9 +64,14 @@ impl Hnsw {
     ///
     /// # Arguments
     /// * `dim` — embedding dimension (must match the vectors passed to `fit` / `knn_query`).
-    /// * `metric` — distance metric. One of `cosine` / `angular`, `euclidean` / `l2`,
-    ///   `dot` / `inner_product`, `manhattan` / `l1`. Names mirror ann-benchmarks
-    ///   conventions so existing harnesses pass their `space` argument unchanged.
+    /// * `metric` — distance metric. Accepted aliases (all case-insensitive):
+    ///     - cosine similarity: `cosine`, `angular`
+    ///     - Euclidean (L2):    `euclidean`, `l2`
+    ///     - dot product:       `dot`, `dot_product`, `ip`, `inner_product`
+    ///     - Manhattan (L1):    `manhattan`, `l1`
+    ///
+    ///   Spellings track ann-benchmarks and VectorDBBench so existing
+    ///   harnesses pass their `space` argument unchanged.
     /// * `M` — max connections per element per layer (HNSW spec). Default 16.
     /// * `ef_construction` — candidate list size during build. Default 200.
     /// * `max_elements` — hint to pre-allocate node storage. Default 1_000_000.
@@ -208,23 +213,31 @@ impl Hnsw {
 
     /// Number of vectors indexed.
     fn __len__(&self) -> PyResult<usize> {
-        // `next_id` is monotonically incremented per insert, so it doubles
-        // as the count without us reaching into HnswIndex internals.
-        let next = self
-            .next_id
+        // Read the count from the HnswIndex itself, NOT from `next_id`.
+        // `next_id` is bumped under its own mutex before the inserts happen
+        // under `inner`; with the GIL released around the build, a concurrent
+        // `__len__` call would otherwise observe phantom IDs that haven't
+        // actually landed in the index.  Locking `inner` makes the count
+        // reflect committed inserts only.
+        let index = self
+            .inner
             .lock()
-            .map_err(|e| PyRuntimeError::new_err(format!("next_id lock poisoned: {e}")))?;
-        Ok(*next as usize)
+            .map_err(|e| PyRuntimeError::new_err(format!("index lock poisoned: {e}")))?;
+        Ok(index.len())
     }
 
     fn __repr__(&self) -> String {
-        // `__len__` surfaces a poisoned mutex as RuntimeError; `__repr__` can't
-        // raise (Python expects it to always return a string) so we emit a
-        // visible marker instead of silently reporting len=0.  Hiding a poisoned
-        // lock would mask real concurrency bugs during debugging.
-        let len_repr = match self.next_id.lock() {
-            Ok(g) => g.to_string(),
-            Err(_) => "<poisoned>".to_owned(),
+        // `__len__` surfaces a poisoned mutex as RuntimeError; `__repr__`
+        // can't raise (Python expects it to always return a string), so a
+        // poison is rendered as a visible marker rather than a silent
+        // `len=0` that would mask real concurrency bugs during debugging.
+        // `try_lock` is intentional: even when uncontended `__repr__` runs
+        // in the debugger and must not block a concurrent build that holds
+        // the lock — we'd rather show `<busy>` than deadlock the REPL.
+        let len_repr = match self.inner.try_lock() {
+            Ok(idx) => idx.len().to_string(),
+            Err(std::sync::TryLockError::WouldBlock) => "<busy>".to_owned(),
+            Err(std::sync::TryLockError::Poisoned(_)) => "<poisoned>".to_owned(),
         };
         format!("Hnsw(dim={}, len={len_repr})", self.dim)
     }

--- a/coordinode-embedded/src/hnsw.rs
+++ b/coordinode-embedded/src/hnsw.rs
@@ -92,9 +92,18 @@ impl Hnsw {
             return Err(PyValueError::new_err("M must be > 0"));
         }
         let metric = parse_metric(metric)?;
+        // `M * 2` would panic in debug / wrap in release for adversarial M
+        // (M ≥ usize::MAX / 2 + 1).  Reject before the engine sees a broken
+        // config; realistic M values are 4..96, so any overflow here is a
+        // caller error, not a workload to support.
+        let m_max0 = M.checked_mul(2).ok_or_else(|| {
+            PyValueError::new_err(format!(
+                "M={M} is too large; M * 2 overflows usize"
+            ))
+        })?;
         let config = HnswConfig {
             m: M,
-            m_max0: M * 2,
+            m_max0,
             ef_construction,
             ef_search: 50,
             metric,

--- a/coordinode-embedded/src/hnsw.rs
+++ b/coordinode-embedded/src/hnsw.rs
@@ -1,0 +1,214 @@
+//! Native PyO3 wrapper around [`coordinode_vector::hnsw::HnswIndex`].
+//!
+//! This is the fast-path bypass used by the ann-benchmarks Docker adapter
+//! and any in-process HNSW workload. It avoids Cypher's parser/planner
+//! overhead so the resulting QPS / recall numbers are directly comparable
+//! with library benchmarks like hnswlib, FAISS-HNSW, ScaNN and Annoy.
+//!
+//! For Cypher-flavoured access (`CREATE VECTOR INDEX`, `MATCH … ORDER BY
+//! vector_similarity(...)`) use `LocalClient` instead.
+
+use std::sync::Mutex;
+
+use coordinode_core::graph::types::VectorMetric;
+use coordinode_vector::hnsw::{HnswConfig, HnswIndex};
+use numpy::{PyArray1, PyReadonlyArray1, PyReadonlyArray2};
+use pyo3::exceptions::{PyRuntimeError, PyValueError};
+use pyo3::prelude::*;
+
+fn parse_metric(s: &str) -> PyResult<VectorMetric> {
+    match s.to_ascii_lowercase().as_str() {
+        "cosine" | "angular" => Ok(VectorMetric::Cosine),
+        "euclidean" | "l2" => Ok(VectorMetric::L2),
+        "dot" | "dot_product" | "ip" | "inner_product" => Ok(VectorMetric::DotProduct),
+        "manhattan" | "l1" => Ok(VectorMetric::L1),
+        other => Err(PyValueError::new_err(format!(
+            "unknown metric '{other}' — expected one of: cosine/angular, euclidean/l2, dot, manhattan/l1"
+        ))),
+    }
+}
+
+/// In-process HNSW index — PyO3 binding around the CoordiNode native engine.
+///
+/// # Example
+///
+/// ```python
+/// import numpy as np
+/// from coordinode_embedded import Hnsw
+///
+/// rng = np.random.default_rng(42)
+/// X = rng.standard_normal((10_000, 128), dtype=np.float32)
+/// q = rng.standard_normal(128, dtype=np.float32)
+///
+/// idx = Hnsw(dim=128, metric="euclidean", M=16, ef_construction=200)
+/// idx.fit(X)
+/// idx.set_ef(80)
+/// labels = idx.knn_query(q, k=10)   # numpy int64 array, shape (10,)
+/// ```
+#[pyclass]
+pub struct Hnsw {
+    inner: Mutex<HnswIndex>,
+    next_id: Mutex<u64>,
+    dim: u32,
+}
+
+#[pymethods]
+impl Hnsw {
+    /// Build a new HNSW index.
+    ///
+    /// # Arguments
+    /// * `dim` — embedding dimension (must match the vectors passed to `fit` / `knn_query`).
+    /// * `metric` — distance metric. One of `cosine` / `angular`, `euclidean` / `l2`,
+    ///   `dot` / `inner_product`, `manhattan` / `l1`. Names mirror ann-benchmarks
+    ///   conventions so existing harnesses pass their `space` argument unchanged.
+    /// * `M` — max connections per element per layer (HNSW spec). Default 16.
+    /// * `ef_construction` — candidate list size during build. Default 200.
+    /// * `max_elements` — hint to pre-allocate node storage. Default 1_000_000.
+    #[new]
+    #[pyo3(signature = (dim, metric, M=16, ef_construction=200, max_elements=1_000_000))]
+    #[allow(non_snake_case)]
+    fn new(
+        dim: u32,
+        metric: &str,
+        M: usize,
+        ef_construction: usize,
+        max_elements: u32,
+    ) -> PyResult<Self> {
+        if dim == 0 {
+            return Err(PyValueError::new_err("dim must be > 0"));
+        }
+        if M == 0 {
+            return Err(PyValueError::new_err("M must be > 0"));
+        }
+        let metric = parse_metric(metric)?;
+        let config = HnswConfig {
+            m: M,
+            m_max0: M * 2,
+            ef_construction,
+            ef_search: 50,
+            metric,
+            max_dimensions: dim,
+            max_elements,
+            ..HnswConfig::default()
+        };
+        Ok(Self {
+            inner: Mutex::new(HnswIndex::new(config)),
+            next_id: Mutex::new(0),
+            dim,
+        })
+    }
+
+    /// Bulk-insert vectors. Accepts a 2-D float32 numpy array of shape `(N, dim)`.
+    ///
+    /// Each row gets an auto-assigned sequential ID starting from the next free
+    /// ID (so multiple `fit` calls extend the index instead of replacing it).
+    /// Returns the contiguous range `[first_id, last_id+1)` as a (start, end) tuple
+    /// so callers can map their own labels onto our internal IDs.
+    fn fit(&self, py: Python<'_>, vectors: PyReadonlyArray2<f32>) -> PyResult<(u64, u64)> {
+        let array = vectors.as_array();
+        let (n, d) = (array.shape()[0], array.shape()[1]);
+        if d as u32 != self.dim {
+            return Err(PyValueError::new_err(format!(
+                "vector dimension mismatch: index dim={}, input dim={d}",
+                self.dim
+            )));
+        }
+        if n == 0 {
+            return Ok((0, 0));
+        }
+        // Materialise the (id, vec) batch under the GIL, then release the GIL
+        // for the build.  Use per-item `insert` rather than `insert_batch`:
+        // the batch path trades within-batch plan staleness for ~5-8× build
+        // throughput, but the resulting recall divergence (engine parity bar
+        // is 0.7 top-10 agreement, not 1.0) is unacceptable for ann-benchmarks
+        // comparisons against serial-equivalent libraries like hnswlib.  We
+        // can expose a `fit_fast` opt-in later if a real workload needs the
+        // build-throughput trade.
+        let mut next = self
+            .next_id
+            .lock()
+            .map_err(|e| PyRuntimeError::new_err(format!("next_id lock poisoned: {e}")))?;
+        let start_id = *next;
+        let mut batch: Vec<(u64, Vec<f32>)> = Vec::with_capacity(n);
+        for row in array.outer_iter() {
+            batch.push((*next, row.to_vec()));
+            *next += 1;
+        }
+        let end_id = *next;
+        drop(next);
+
+        py.allow_threads(|| -> PyResult<()> {
+            let mut index = self
+                .inner
+                .lock()
+                .map_err(|e| PyRuntimeError::new_err(format!("index lock poisoned: {e}")))?;
+            for (id, vec) in batch {
+                index.insert(id, vec);
+            }
+            Ok(())
+        })?;
+        Ok((start_id, end_id))
+    }
+
+    /// Update runtime `ef_search`. Larger ef = higher recall, lower QPS.
+    fn set_ef(&self, ef: usize) -> PyResult<()> {
+        let mut index = self
+            .inner
+            .lock()
+            .map_err(|e| PyRuntimeError::new_err(format!("index lock poisoned: {e}")))?;
+        index.set_ef_search(ef);
+        Ok(())
+    }
+
+    /// k-NN query. Returns a 1-D int64 numpy array of length `k` with the IDs
+    /// of the nearest neighbours, ordered nearest-first. If the index has
+    /// fewer than `k` elements, the result is shorter accordingly.
+    fn knn_query<'py>(
+        &self,
+        py: Python<'py>,
+        query: PyReadonlyArray1<f32>,
+        k: usize,
+    ) -> PyResult<Bound<'py, PyArray1<i64>>> {
+        let q_view = query.as_array();
+        if q_view.len() as u32 != self.dim {
+            return Err(PyValueError::new_err(format!(
+                "query dimension mismatch: index dim={}, query dim={}",
+                self.dim,
+                q_view.len()
+            )));
+        }
+        let q: Vec<f32> = q_view.iter().copied().collect();
+        let labels = py.allow_threads(|| -> PyResult<Vec<i64>> {
+            let index = self
+                .inner
+                .lock()
+                .map_err(|e| PyRuntimeError::new_err(format!("index lock poisoned: {e}")))?;
+            Ok(index
+                .search(&q, k)
+                .into_iter()
+                .map(|r| r.id as i64)
+                .collect())
+        })?;
+        Ok(PyArray1::from_vec(py, labels))
+    }
+
+    /// Number of vectors indexed.
+    fn __len__(&self) -> PyResult<usize> {
+        // `next_id` is monotonically incremented per insert, so it doubles
+        // as the count without us reaching into HnswIndex internals.
+        let next = self
+            .next_id
+            .lock()
+            .map_err(|e| PyRuntimeError::new_err(format!("next_id lock poisoned: {e}")))?;
+        Ok(*next as usize)
+    }
+
+    fn __repr__(&self) -> String {
+        let n = self
+            .next_id
+            .lock()
+            .map(|g| *g)
+            .unwrap_or(0);
+        format!("Hnsw(dim={}, len={})", self.dim, n)
+    }
+}

--- a/coordinode-embedded/src/hnsw.rs
+++ b/coordinode-embedded/src/hnsw.rs
@@ -16,6 +16,12 @@ use numpy::{PyArray1, PyReadonlyArray1, PyReadonlyArray2};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 
+/// All accepted spellings, kept beside [`parse_metric`] so the error message
+/// and the match arms cannot drift.  When this list changes, the parser is
+/// the source of truth — bump both at once.
+const ACCEPTED_METRICS: &str =
+    "cosine, angular, euclidean, l2, dot, dot_product, ip, inner_product, manhattan, l1";
+
 fn parse_metric(s: &str) -> PyResult<VectorMetric> {
     match s.to_ascii_lowercase().as_str() {
         "cosine" | "angular" => Ok(VectorMetric::Cosine),
@@ -23,7 +29,7 @@ fn parse_metric(s: &str) -> PyResult<VectorMetric> {
         "dot" | "dot_product" | "ip" | "inner_product" => Ok(VectorMetric::DotProduct),
         "manhattan" | "l1" => Ok(VectorMetric::L1),
         other => Err(PyValueError::new_err(format!(
-            "unknown metric '{other}' — expected one of: cosine/angular, euclidean/l2, dot, manhattan/l1"
+            "unknown metric '{other}' — accepted: {ACCEPTED_METRICS}"
         ))),
     }
 }
@@ -45,7 +51,7 @@ fn parse_metric(s: &str) -> PyResult<VectorMetric> {
 /// idx.set_ef(80)
 /// labels = idx.knn_query(q, k=10)   # numpy int64 array, shape (10,)
 /// ```
-#[pyclass]
+#[pyclass(module = "coordinode_embedded")]
 pub struct Hnsw {
     inner: Mutex<HnswIndex>,
     next_id: Mutex<u64>,
@@ -212,11 +218,14 @@ impl Hnsw {
     }
 
     fn __repr__(&self) -> String {
-        let n = self
-            .next_id
-            .lock()
-            .map(|g| *g)
-            .unwrap_or(0);
-        format!("Hnsw(dim={}, len={})", self.dim, n)
+        // `__len__` surfaces a poisoned mutex as RuntimeError; `__repr__` can't
+        // raise (Python expects it to always return a string) so we emit a
+        // visible marker instead of silently reporting len=0.  Hiding a poisoned
+        // lock would mask real concurrency bugs during debugging.
+        let len_repr = match self.next_id.lock() {
+            Ok(g) => g.to_string(),
+            Err(_) => "<poisoned>".to_owned(),
+        };
+        format!("Hnsw(dim={}, len={len_repr})", self.dim)
     }
 }

--- a/coordinode-embedded/src/hnsw.rs
+++ b/coordinode-embedded/src/hnsw.rs
@@ -114,7 +114,15 @@ impl Hnsw {
             )));
         }
         if n == 0 {
-            return Ok((0, 0));
+            // Empty batch is a no-op but must still report the current insertion
+            // point — returning (0, 0) would break the "contiguous range
+            // [first_id, last_id+1) at the actual insertion point" contract once
+            // the index already holds vectors.
+            let next = self
+                .next_id
+                .lock()
+                .map_err(|e| PyRuntimeError::new_err(format!("next_id lock poisoned: {e}")))?;
+            return Ok((*next, *next));
         }
         // Materialise the (id, vec) batch under the GIL, then release the GIL
         // for the build.  Use per-item `insert` rather than `insert_batch`:

--- a/coordinode-embedded/src/lib.rs
+++ b/coordinode-embedded/src/lib.rs
@@ -317,8 +317,10 @@ fn _coordinode_embedded(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // No explicit NumPy C-API initialization here.  The `numpy` crate
     // (see crate-level docs: "Loading NumPy is done automatically and on
     // demand") triggers `import numpy.core` lazily the first time a
-    // PyArray operation runs.  An explicit init step would be a no-op
-    // and there is no public initializer in numpy 0.23.
+    // PyArray operation runs.  An explicit init step would be a no-op —
+    // the crate exposes no public initializer (verified against the
+    // 0.23/0.24 lines, and that policy is unlikely to change while the
+    // crate's lazy-import design holds).
     m.add_class::<LocalClient>()?;
     m.add_class::<hnsw::Hnsw>()?;
     Ok(())

--- a/coordinode-embedded/src/lib.rs
+++ b/coordinode-embedded/src/lib.rs
@@ -1,3 +1,5 @@
+mod hnsw;
+
 /// CoordiNode embedded Python bindings.
 ///
 /// Exposes `LocalClient` — a `CoordinodeClient`-compatible interface that runs
@@ -313,5 +315,6 @@ impl LocalClient {
 #[pymodule]
 fn _coordinode_embedded(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<LocalClient>()?;
+    m.add_class::<hnsw::Hnsw>()?;
     Ok(())
 }

--- a/coordinode-embedded/src/lib.rs
+++ b/coordinode-embedded/src/lib.rs
@@ -314,6 +314,11 @@ impl LocalClient {
 
 #[pymodule]
 fn _coordinode_embedded(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    // No explicit NumPy C-API initialization here.  The `numpy` crate
+    // (see crate-level docs: "Loading NumPy is done automatically and on
+    // demand") triggers `import numpy.core` lazily the first time a
+    // PyArray operation runs.  An explicit init step would be a no-op
+    // and there is no public initializer in numpy 0.23.
     m.add_class::<LocalClient>()?;
     m.add_class::<hnsw::Hnsw>()?;
     Ok(())

--- a/tests/unit/test_hnsw.py
+++ b/tests/unit/test_hnsw.py
@@ -14,8 +14,11 @@ ce = pytest.importorskip("coordinode_embedded")
 
 
 def _brute_force_topk(X, q, k: int):
+    # argpartition gives the top-k indices in O(N), vs argsort's O(N log N).
+    # We only need the SET of nearest k, ordering inside the set doesn't
+    # matter for the recall metric.
     dists = ((X - q) ** 2).sum(axis=1)
-    return set(np.argsort(dists)[:k].tolist())
+    return set(np.argpartition(dists, k)[:k].tolist())
 
 
 def test_metric_parsing_and_dim_validation() -> None:
@@ -59,8 +62,10 @@ def test_recall_at_10_geq_0_95() -> None:
     we hold queries out of the training set).
     """
     rng = np.random.default_rng(42)
-    X = rng.standard_normal((10_000, 16)).astype(np.float32)
-    queries = rng.standard_normal((50, 16)).astype(np.float32)
+    # `dtype=` on standard_normal skips the float64-then-astype round-trip,
+    # halving the allocation for this 10K × 16 matrix.
+    X = rng.standard_normal((10_000, 16), dtype=np.float32)
+    queries = rng.standard_normal((50, 16), dtype=np.float32)
 
     idx = ce.Hnsw(dim=16, metric="euclidean", M=16, ef_construction=200)
     idx.fit(X)

--- a/tests/unit/test_hnsw.py
+++ b/tests/unit/test_hnsw.py
@@ -28,12 +28,15 @@ def test_metric_parsing_and_dim_validation() -> None:
     ce.Hnsw(dim=4, metric="cosine", M=4, ef_construction=20)
     ce.Hnsw(dim=4, metric="l1", M=4, ef_construction=20)
     ce.Hnsw(dim=4, metric="dot", M=4, ef_construction=20)
+    # "inner_product" is a documented alias for "dot" — exercise it explicitly
+    # so a future rename in the Rust metric parser can't silently drop it.
+    ce.Hnsw(dim=4, metric="inner_product", M=4, ef_construction=20)
     with pytest.raises(ValueError):
         ce.Hnsw(dim=4, metric="bogus", M=4, ef_construction=20)
 
     # Dimension mismatch on fit / query surfaces as ValueError, not panic.
     with pytest.raises(ValueError):
-        idx.fit(np.zeros((3, 7), dtype=np.float32))   # 7 ≠ 8
+        idx.fit(np.zeros((3, 7), dtype=np.float32))  # 7 ≠ 8
     idx.fit(np.zeros((3, 8), dtype=np.float32))
     with pytest.raises(ValueError):
         idx.knn_query(np.zeros(7, dtype=np.float32), k=3)
@@ -72,9 +75,7 @@ def test_recall_at_10_geq_0_95() -> None:
             ok += len(truths[i] & got)
             total += 10
         recall = ok / total
-        assert recall >= min_recall, (
-            f"recall@10 at ef={ef} = {recall:.3f} (expected ≥ {min_recall})"
-        )
+        assert recall >= min_recall, f"recall@10 at ef={ef} = {recall:.3f} (expected ≥ {min_recall})"
 
 
 def test_knn_query_returns_int64_array() -> None:
@@ -84,4 +85,4 @@ def test_knn_query_returns_int64_array() -> None:
     assert isinstance(out, np.ndarray)
     assert out.dtype == np.int64
     assert out.shape == (3,)
-    assert out[0] == 0    # the eye row most similar to (1,0,0,0)
+    assert out[0] == 0  # the eye row most similar to (1,0,0,0)

--- a/tests/unit/test_hnsw.py
+++ b/tests/unit/test_hnsw.py
@@ -1,0 +1,87 @@
+"""Recall + API tests for the native ``Hnsw`` PyO3 binding.
+
+Skipped on fresh checkouts where ``coordinode_embedded`` has not been built
+via ``maturin develop``.  Exercised by the ``build-embedded`` CI job after
+the wheel is installed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+np = pytest.importorskip("numpy")
+ce = pytest.importorskip("coordinode_embedded")
+
+
+def _brute_force_topk(X, q, k: int):
+    dists = ((X - q) ** 2).sum(axis=1)
+    return set(np.argsort(dists)[:k].tolist())
+
+
+def test_metric_parsing_and_dim_validation() -> None:
+    idx = ce.Hnsw(dim=8, metric="euclidean", M=4, ef_construction=20)
+    assert len(idx) == 0
+
+    # Unknown metric raises early — agentic adapters often pass through
+    # ann-benchmarks's "angular" alias, so both spellings must work.
+    ce.Hnsw(dim=4, metric="angular", M=4, ef_construction=20)
+    ce.Hnsw(dim=4, metric="cosine", M=4, ef_construction=20)
+    ce.Hnsw(dim=4, metric="l1", M=4, ef_construction=20)
+    ce.Hnsw(dim=4, metric="dot", M=4, ef_construction=20)
+    with pytest.raises(ValueError):
+        ce.Hnsw(dim=4, metric="bogus", M=4, ef_construction=20)
+
+    # Dimension mismatch on fit / query surfaces as ValueError, not panic.
+    with pytest.raises(ValueError):
+        idx.fit(np.zeros((3, 7), dtype=np.float32))   # 7 ≠ 8
+    idx.fit(np.zeros((3, 8), dtype=np.float32))
+    with pytest.raises(ValueError):
+        idx.knn_query(np.zeros(7, dtype=np.float32), k=3)
+
+
+def test_fit_returns_contiguous_id_range() -> None:
+    idx = ce.Hnsw(dim=4, metric="euclidean", M=4, ef_construction=20)
+    a = idx.fit(np.zeros((10, 4), dtype=np.float32))
+    b = idx.fit(np.zeros((5, 4), dtype=np.float32))
+    assert a == (0, 10)
+    assert b == (10, 15)
+    assert len(idx) == 15
+
+
+def test_recall_at_10_geq_0_95() -> None:
+    """N=10 000, dim=16, gaussian random — at ef ≥ 50 recall@10 must clear 0.95.
+
+    Matches the engine's own ``hnsw::tests::recall_test_l2`` bar but at
+    realistic scale (the native test runs at n=200 with self-queries; here
+    we hold queries out of the training set).
+    """
+    rng = np.random.default_rng(42)
+    X = rng.standard_normal((10_000, 16)).astype(np.float32)
+    queries = rng.standard_normal((50, 16)).astype(np.float32)
+
+    idx = ce.Hnsw(dim=16, metric="euclidean", M=16, ef_construction=200)
+    idx.fit(X)
+
+    truths = [_brute_force_topk(X, q, 10) for q in queries]
+
+    for ef, min_recall in [(50, 0.95), (100, 0.98), (200, 0.99)]:
+        idx.set_ef(ef)
+        ok, total = 0, 0
+        for i, q in enumerate(queries):
+            got = set(idx.knn_query(q, k=10).tolist())
+            ok += len(truths[i] & got)
+            total += 10
+        recall = ok / total
+        assert recall >= min_recall, (
+            f"recall@10 at ef={ef} = {recall:.3f} (expected ≥ {min_recall})"
+        )
+
+
+def test_knn_query_returns_int64_array() -> None:
+    idx = ce.Hnsw(dim=4, metric="euclidean", M=4, ef_construction=20)
+    idx.fit(np.eye(4, dtype=np.float32))
+    out = idx.knn_query(np.array([1, 0, 0, 0], dtype=np.float32), k=3)
+    assert isinstance(out, np.ndarray)
+    assert out.dtype == np.int64
+    assert out.shape == (3,)
+    assert out[0] == 0    # the eye row most similar to (1,0,0,0)

--- a/tests/unit/test_hnsw.py
+++ b/tests/unit/test_hnsw.py
@@ -16,14 +16,11 @@ ce = pytest.importorskip("coordinode_embedded")
 def _brute_force_topk(X, q, k: int):
     # argpartition gives the top-k indices in O(N), vs argsort's O(N log N).
     # We only need the SET of nearest k, ordering inside the set doesn't
-    # matter for the recall metric.
-    #
-    # The `k` argument to argpartition is the pivot index, NOT an off-by-one:
-    # numpy places the (k+1)-th smallest at position k, with everything
-    # smaller at positions 0..k-1.  So `[:k]` gives exactly the k smallest
-    # — verified empirically against np.argsort on random vectors.
+    # matter for the recall metric.  Pivot is k-1 (0-indexed) so the
+    # element at position k-1 lands at its sorted position and everything
+    # smaller is at 0..k-2 — slice [:k] yields the k smallest.
     dists = ((X - q) ** 2).sum(axis=1)
-    return set(np.argpartition(dists, k)[:k].tolist())
+    return set(np.argpartition(dists, k - 1)[:k].tolist())
 
 
 def test_metric_parsing_and_dim_validation() -> None:

--- a/tests/unit/test_hnsw.py
+++ b/tests/unit/test_hnsw.py
@@ -17,6 +17,11 @@ def _brute_force_topk(X, q, k: int):
     # argpartition gives the top-k indices in O(N), vs argsort's O(N log N).
     # We only need the SET of nearest k, ordering inside the set doesn't
     # matter for the recall metric.
+    #
+    # The `k` argument to argpartition is the pivot index, NOT an off-by-one:
+    # numpy places the (k+1)-th smallest at position k, with everything
+    # smaller at positions 0..k-1.  So `[:k]` gives exactly the k smallest
+    # — verified empirically against np.argsort on random vectors.
     dists = ((X - q) ** 2).sum(axis=1)
     return set(np.argpartition(dists, k)[:k].tolist())
 


### PR DESCRIPTION
## Summary

- New PyO3 \`Hnsw\` class in \`coordinode-embedded\` — a Cypher-bypass path to \`coordinode_vector::hnsw::HnswIndex\`. Mirrors the hnswlib \`BaseANN\` surface so the ann-benchmarks Docker adapter is a one-line wrapper around it.
- Numpy-native I/O: \`fit(np.ndarray[float32, 2D])\`, \`knn_query(np.ndarray[float32, 1D], k) -> np.ndarray[int64, 1D]\`.
- Bumps \`coordinode-rs\` submodule to current main (newer HnswIndex API + saturation-path fix from f763f86).

## Why

Existing \`LocalClient\` exposes the engine through Cypher (parser + planner + executor). Useful for end-to-end SDK demos but not comparable with in-process HNSW libraries (hnswlib / FAISS / ScaNN / Annoy) on a like-for-like basis. To get CoordiNode on the canonical [ann-benchmarks.com](https://ann-benchmarks.com) leaderboard, and to drive the per-commit vector benchmark dashboard on docs.coordinode.com, we need a Cypher-bypass binding.

## API surface

\`\`\`python
import numpy as np
from coordinode_embedded import Hnsw

rng = np.random.default_rng(42)
X = rng.standard_normal((10_000, 16), dtype=np.float32)
q = rng.standard_normal(16, dtype=np.float32)

idx = Hnsw(dim=16, metric=\"euclidean\", M=16, ef_construction=200)
idx.fit(X)
idx.set_ef(80)
labels = idx.knn_query(q, k=10)   # np.ndarray[int64], shape (10,)
\`\`\`

## Design notes

- **GIL released** around build and search via \`py.allow_threads\`.
- **Auto IDs**: \`fit\` returns the contiguous \`(start, end)\` range it assigned. Multiple \`fit\` calls extend the index. Adapters that need to track their own labels keep their own mapping.
- **Serial insert, not insert_batch**. \`insert_batch\` trades within-batch plan staleness for ~5-8× build throughput, but the engine's parity test only requires 0.7 top-10 agreement vs serial — that's fine inside the engine but unacceptable in a head-to-head with hnswlib on ann-benchmarks. A \`fit_fast\` opt-in can land later for workloads that prefer build throughput.
- **Metric aliases** track ann-benchmarks conventions: \`angular\` / \`cosine\`, \`euclidean\` / \`l2\`, \`dot\` / \`inner_product\`, \`manhattan\` / \`l1\`. Unknown metric raises \`ValueError\`.
- **Dimension validation** raises \`ValueError\` rather than panic on shape mismatch.

## Tests

\`tests/unit/test_hnsw.py\` — 4 tests:
- Metric parsing + dim validation
- ID range bookkeeping across multiple \`fit\` calls
- Recall@10 bar at N=10 000, dim=16: ≥ 0.95 at ef=50, ≥ 0.98 at ef=100, ≥ 0.99 at ef=200
- Return type assertion (int64 ndarray, shape (k,))

\`\`\`
pytest tests/unit/test_hnsw.py -v
============================== 4 passed in 5.51s ==============================
\`\`\`

Local smoke (M1 macOS):
\`\`\`
Built N=10000, dim=16 in 2.96s
ef=10:  recall@10 = 0.872, QPS = 39115
ef=50:  recall@10 = 0.990, QPS = 10908
ef=100: recall@10 = 0.998, QPS =  5262
ef=200: recall@10 = 0.999, QPS =  3047
\`\`\`

## Follow-up (separate work, NOT in this PR)

- \`benches/ann-benchmarks-adapter/\` in coordinode repo — thin BaseANN wrapper + Dockerfile + sweep config
- Bench CI on self-hosted ro: per-commit submodule swap → wheel build → ann-benchmarks run → JSON to bench-data branch
- Upstream PR to \`erikbern/ann-benchmarks\` once \`coordinode-embedded\` ships a stable PyPI release

Closes #69